### PR TITLE
Accelerate box labeling

### DIFF
--- a/utils/nms.py
+++ b/utils/nms.py
@@ -6,7 +6,7 @@ class NMS(object):
     def __init__(self):
         super(NMS, self).__init__()
         self.max_box_num = MAX_BOX_NUM
-        self.num_class = NUM_CLASSES + 1
+        self.num_class = NUM_CLASSES
 
     def nms(self, boxes, box_scores):
         mask = box_scores >= CONFIDENCE_THRESHOLD


### PR DESCRIPTION
- Change for-loop iou calculation to once
- Change for-loop get-offset to once
- Change number of classes in nms

In my case (Intel(R) Core(TM) i7-6850K CPU @ 3.60GHz, NVIDIA GeForce GTX 1080Ti)
-> Time per step reduced from 15.3s/step to 0.73s/step